### PR TITLE
fix open dropdown when click outside the input

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,7 +7,7 @@
         <form [formGroup]='stateForm' autocomplete="new-password" novalidate>
             <input id='search' placeholder="Search for a state" formControlName='search' (click)=' openDropDown() ' class=' input-underline search-bar ' type='text'>
         </form>
-        <div clickOutside (clickOutside)="closeDropDown()">
+        <div clickOutside (clickOutside)="closeDropDown()" ignoreOnId="search">
             <div *ngIf='showDropDown' class='search-drop-down '>
                 <div (click)='selectValue(s)' class='search-results ' *ngFor="let s of states | searchFilter: getSearchValue()">
                     <a [innerHTML]="s | letterBold: getSearchValue()">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -37,14 +37,14 @@ export class AppComponent implements OnInit {
 
  selectValue(value) {
    this.stateForm.patchValue({"search": value});
-   this.showDropDown = false;
+   this.closeDropDown();
  }
   closeDropDown() {
-    this.showDropDown = !this.showDropDown;
+    this.showDropDown = false;
   }
 
   openDropDown() {
-    this.showDropDown = false;
+    this.showDropDown = true;
   }
 
   getSearchValue() {

--- a/src/app/shared/dropdown.directive.ts
+++ b/src/app/shared/dropdown.directive.ts
@@ -1,9 +1,11 @@
-import { Directive, ElementRef, Output, EventEmitter, HostListener } from '@angular/core';
+import { Directive, ElementRef, Output, EventEmitter, HostListener, Input } from '@angular/core';
 
 @Directive({
     selector: '[clickOutside]',
 })
 export class ClickOutsideDirective {
+    @Input('ignoreOnId') ignoreOnId: string;
+
     @Output() public clickOutside = new EventEmitter();
     constructor(private _elementRef: ElementRef) {
 
@@ -11,6 +13,9 @@ export class ClickOutsideDirective {
 
     @HostListener('document:click', ['$event.target'])
     public onClick(targetElement) {
+        if (this.ignoreOnId && targetElement.id === this.ignoreOnId) {
+            return;
+        }
         const isClickedInside = this._elementRef.nativeElement.contains(targetElement);
         if (!isClickedInside) {
             this.clickOutside.emit(null);


### PR DESCRIPTION
When the dropdown is closed and the user clicks outside, it was openning. 
I fixed that by adding a parameter to the directive, the id of an element that shouldn't emit the clickOutside event when clicked and passing the "search" id to don't emit this event when the user clicks on the input element. This allowed to change openDropDown and closeDropDown methods to work as expected.